### PR TITLE
chore: sync to latest iox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "tokio",
 ]
@@ -1493,7 +1493,7 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "chrono",
@@ -1513,7 +1513,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1530,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-array"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1590,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "ahash",
  "arrow",
@@ -1681,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "chrono",
@@ -1695,7 +1695,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "38.0.0"
-source = "git+https://github.com/apache/datafusion.git?rev=e0245296792eabdc35e83e8c5872345ff38c1fdf#e0245296792eabdc35e83e8c5872345ff38c1fdf"
+source = "git+https://github.com/apache/datafusion.git?rev=5fac581efbaffd0e6a9edf931182517524526afd#5fac581efbaffd0e6a9edf931182517524526afd"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1883,12 +1883,9 @@ dependencies = [
  "futures",
  "metric",
  "observability_deps",
- "once_cell",
  "parking_lot",
- "pin-project",
  "snafu 0.8.2",
  "tokio",
- "tokio-util",
  "tokio_metrics_bridge",
  "tokio_watchdog",
  "workspace-hack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,8 +89,8 @@ license = "MIT OR Apache-2.0"
 arrow = { version = "51.0.0", features = ["prettyprint", "chrono-tz"] }
 arrow-buffer = { version = "51.0.0" }
 arrow-flight = { version = "51.0.0", features = ["flight-sql-experimental"] }
-datafusion = { git = "https://github.com/apache/datafusion.git", rev = "e0245296792eabdc35e83e8c5872345ff38c1fdf" }
-datafusion-proto = { git = "https://github.com/apache/datafusion.git", rev = "e0245296792eabdc35e83e8c5872345ff38c1fdf" }
+datafusion = { git = "https://github.com/apache/datafusion.git", rev = "5fac581efbaffd0e6a9edf931182517524526afd" }
+datafusion-proto = { git = "https://github.com/apache/datafusion.git", rev = "5fac581efbaffd0e6a9edf931182517524526afd" }
 hashbrown = { version = "0.14.5" }
 object_store = { version = "0.9.1" }
 parquet = { version = "51.0.0", features = ["object_store"] }

--- a/data_types/Cargo.toml
+++ b/data_types/Cargo.toml
@@ -14,7 +14,7 @@ arrow = { workspace = true }
 arrow-buffer = { workspace = true }
 bytes = "1.6"
 chrono = { version = "0.4", default-features = false }
-croaring = "1.0.0"
+croaring = "1.1.0"
 influxdb-line-protocol = { path = "../influxdb_line_protocol" }
 iox_time = { path = "../iox_time" }
 generated_types = { path = "../generated_types" }

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -12,12 +12,9 @@ workspace = true
 futures = "0.3"
 metric = { path = "../metric" }
 observability_deps = { path = "../observability_deps" }
-once_cell = { version = "1.19", features = ["parking_lot"] }
 parking_lot = "0.12"
-pin-project = "1.1"
 snafu = "0.8"
 tokio = { version = "1.37" }
-tokio-util = { version = "0.7.11" }
 tokio_metrics_bridge = { path = "../tokio_metrics_bridge" }
 tokio_watchdog = { path = "../tokio_watchdog" }
 workspace-hack = { version = "0.1", path = "../workspace-hack" }

--- a/iox_catalog/src/cache/handler.rs
+++ b/iox_catalog/src/cache/handler.rs
@@ -150,7 +150,7 @@ where
         // of racing writers or only two available replicas. We should only log if
         // the deadline expires
         let res = loop {
-            let mut span_recorder = span_recorder.child("retry round");
+            let mut span_recorder = span_recorder.child("retry_round");
             match self.inner.cache.get(key).await {
                 Ok(val) => {
                     span_recorder.ok("ok");
@@ -292,7 +292,7 @@ where
         let key = k.to_key();
 
         match self
-            .get_quorum(key, span_recorder.child_span("get quorum"))
+            .get_quorum(key, span_recorder.child_span("get_quorum"))
             .await
         {
             Ok(Some(val)) => {

--- a/iox_query/src/exec/context.rs
+++ b/iox_query/src/exec/context.rs
@@ -260,7 +260,7 @@ impl IOxSessionConfig {
 
     /// Create an ExecutionContext suitable for executing DataFusion plans
     pub fn build(self) -> IOxSessionContext {
-        let maybe_span = self.span_ctx.child_span("Query Execution");
+        let maybe_span = self.span_ctx.child_span("query_planning");
         let recorder = SpanRecorder::new(maybe_span);
 
         // attach span to DataFusion session

--- a/iox_query/src/frontend/sql.rs
+++ b/iox_query/src/frontend/sql.rs
@@ -20,7 +20,7 @@ impl SqlQueryPlanner {
         params: impl Into<ParamValues> + Send,
         ctx: &IOxSessionContext,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let ctx = ctx.child_ctx("SqlQueryPlanner::query");
+        let ctx = ctx.child_ctx("sql_query_planner");
         ctx.sql_to_physical_plan_with_params(query, params).await
     }
 }

--- a/metric/src/counter.rs
+++ b/metric/src/counter.rs
@@ -41,7 +41,7 @@ impl MetricObserver for U64Counter {
 #[macro_export]
 macro_rules! assert_counter {
     (
-        $metrics:ident,
+        $metrics:expr,
         $counter:ty,
         $name:expr,
         $(labels = $attr:expr,)*

--- a/metric/src/histogram.rs
+++ b/metric/src/histogram.rs
@@ -130,7 +130,7 @@ impl MetricObserver for U64Histogram {
 #[macro_export]
 macro_rules! assert_histogram {
     (
-        $metrics:ident,
+        $metrics:expr,
         $hist:ty,
         $name:expr,
         $(labels = $attr:expr,)*

--- a/service_grpc_flight/src/lib.rs
+++ b/service_grpc_flight/src/lib.rs
@@ -605,7 +605,7 @@ impl FlightService {
         let db = server
             .namespace(
                 namespace_name,
-                span_ctx.child_span("get namespace"),
+                span_ctx.child_span("get_namespace"),
                 is_debug,
             )
             .await
@@ -876,7 +876,7 @@ impl Flight for FlightService {
             .server
             .namespace(
                 &namespace_name,
-                span_ctx.child_span("get namespace"),
+                span_ctx.child_span("get_namespace"),
                 is_debug,
             )
             .await
@@ -963,7 +963,7 @@ impl Flight for FlightService {
             .server
             .namespace(
                 &namespace_name,
-                span_ctx.child_span("get namespace"),
+                span_ctx.child_span("get_namespace"),
                 is_debug,
             )
             .await
@@ -1019,7 +1019,7 @@ impl Flight for FlightService {
             .server
             .namespace(
                 &namespace_name,
-                span_ctx.child_span("get namespace"),
+                span_ctx.child_span("get_namespace"),
                 is_debug,
             )
             .await
@@ -1217,7 +1217,7 @@ impl GetStream {
         // acquire token (after planning)
         let permit_state: Arc<Mutex<Option<PermitAndToken>>> = Default::default();
         let permit_state_captured = Arc::clone(&permit_state);
-        let permit_span = ctx.child_span("query rate limit semaphore");
+        let permit_span = ctx.child_span("query_rate_limit_semaphore");
         let query_results = futures::stream::once(async move {
             let permit = server.acquire_semaphore(permit_span).await;
             let query_completed_token = query_completed_token.permit();

--- a/service_grpc_flight/src/planner.rs
+++ b/service_grpc_flight/src/planner.rs
@@ -30,7 +30,7 @@ impl Planner {
     /// Create a new planner that will plan queries using the provided context
     pub(crate) fn new(ctx: &IOxSessionContext) -> Self {
         Self {
-            ctx: ctx.child_ctx("Planner"),
+            ctx: ctx.child_ctx("flight_planner"),
         }
     }
 
@@ -43,7 +43,7 @@ impl Planner {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let planner = SqlQueryPlanner::new();
         let query = query.as_ref();
-        let ctx = self.ctx.child_ctx("planner sql");
+        let ctx = self.ctx.child_ctx("planner_sql");
 
         planner.query(query, params, &ctx).await
     }
@@ -57,7 +57,7 @@ impl Planner {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let planner = InfluxQLQueryPlanner::new();
         let query = query.as_ref();
-        let ctx = self.ctx.child_ctx("planner influxql");
+        let ctx = self.ctx.child_ctx("planner_influxql");
 
         planner.query(query, params, &ctx).await
     }
@@ -71,7 +71,7 @@ impl Planner {
         cmd: FlightSQLCommand,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let namespace_name = namespace_name.as_ref();
-        let ctx = self.ctx.child_ctx("planner flight_sql_do_get");
+        let ctx = self.ctx.child_ctx("planner_flight_sql_do_get");
 
         FlightSQLPlanner::do_get(namespace_name, namespace, cmd, &ctx)
             .await
@@ -87,7 +87,7 @@ impl Planner {
         cmd: FlightSQLCommand,
     ) -> Result<Bytes> {
         let namespace_name = namespace_name.into();
-        let ctx = self.ctx.child_ctx("planner flight_sql_do_action");
+        let ctx = self.ctx.child_ctx("planner_flight_sql_do_action");
 
         FlightSQLPlanner::do_action(namespace_name, namespace, cmd, &ctx)
             .await
@@ -104,7 +104,7 @@ impl Planner {
         data: Peekable<Streaming<FlightData>>,
     ) -> Result<Bytes> {
         let namespace_name = namespace_name.into();
-        let ctx = self.ctx.child_ctx("planner flight_sql_do_put");
+        let ctx = self.ctx.child_ctx("planner_flight_sql_do_put");
 
         FlightSQLPlanner::do_put(namespace_name, namespace, cmd, data, &ctx)
             .await
@@ -120,7 +120,7 @@ impl Planner {
         cmd: FlightSQLCommand,
     ) -> Result<SchemaRef> {
         let namespace_name = namespace_name.into();
-        let ctx = self.ctx.child_ctx("planner flight_sql_get_flight_info");
+        let ctx = self.ctx.child_ctx("planner_flight_sql_get_flight_info");
 
         FlightSQLPlanner::get_schema(namespace_name, cmd, &ctx)
             .await


### PR DESCRIPTION
Sync to latest IOx.

Main changes needed in this:
* added `filter` and `limit` parameters to the `IoxSystemTable::scan` method so that we can pass query predicates to the system table implementations

PR in `influxdb` that points to this change here: https://github.com/influxdata/influxdb/pull/25005

IOx revision range: `c0984b837`..`f7f0fa756`