### PR TITLE
Fix bug in MockParquetFileRepo.

### DIFF
--- a/garbage_collector/src/objectstore/checker.rs
+++ b/garbage_collector/src/objectstore/checker.rs
@@ -740,7 +740,8 @@ mod tests {
             create: &[ParquetFileParams],
             target_level: CompactionLevel,
         ) -> iox_catalog::interface::Result<Vec<ParquetFileId>> {
-            self.create_upgrade_delete(partition_id, delete, upgrade, create, target_level)
+            self.inner
+                .create_upgrade_delete(partition_id, delete, upgrade, create, target_level)
                 .await
         }
     }


### PR DESCRIPTION
There must be bugs here, or makes no sense for the function‘s self calling.