### PR TITLE
support building on fedora

### DIFF
--- a/generated_types/build.rs
+++ b/generated_types/build.rs
@@ -122,11 +122,19 @@ fn generate_grpc_types(root: &Path) -> Result<()> {
         .bytes([".influxdata.iox.catalog_cache.v1"]);
 
     let descriptor_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("proto_descriptor.bin");
+
+    // distributions which obtain `google/protobuf/{duration,timestamp}.proto` from rpm package:
+    // `protobuf-devel` (eg: centos, fedora, etc), require a `--proto_path=/usr/include` protoc arg
+    let protobuf_devel_include_path = PathBuf::from("/usr/include");
+    let includes = vec![
+        root,
+        protobuf_devel_include_path.as_path(),
+    ];
     tonic_build::configure()
         .file_descriptor_set_path(&descriptor_path)
         // protoc in ubuntu builder needs this option
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_with_config(config, &proto_files, &[root])?;
+        .compile_with_config(config, &proto_files, &includes)?;
 
     let descriptor_set = std::fs::read(descriptor_path)?;
 

--- a/grpc-binary-logger-proto/build.rs
+++ b/grpc-binary-logger-proto/build.rs
@@ -1,8 +1,21 @@
 //! Compiles Protocol Buffers into native Rust types.
 //! <https://github.com/grpc/grpc/blob/master/doc/binary-logging.md>
 
+use std::env;
 use std::io::Result;
+use std::path::PathBuf;
 
 fn main() -> Result<()> {
-    tonic_build::compile_protos("proto/grpc/binlog/v1/binarylog.proto")
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("proto");
+    let proto_files = vec![
+        root.join("grpc/binlog/v1/binarylog.proto"),
+    ];
+    // distributions which obtain `google/protobuf/{duration,timestamp}.proto` from rpm package:
+    // `protobuf-devel` (eg: centos, fedora, etc), require a `--proto_path=/usr/include` protoc arg
+    let protobuf_devel_include_path = PathBuf::from("/usr/include");
+    let includes = vec![
+        root,
+        protobuf_devel_include_path,
+    ];
+    tonic_build::configure().compile(&proto_files, &includes)
 }


### PR DESCRIPTION
cargo build fails on distros which make use of the [protobuf-devel](https://packages.fedoraproject.org/pkgs/protobuf/protobuf-devel/index.html) rpm package for well known google protobuf types:
- /usr/include/google/protobuf/duration.proto
- /usr/include/google/protobuf/timestamp.proto

this patch configures cargo to include the `/usr/include` path in the protoc command, allowing protoc access to the duration.proto and timestamp.proto types included by the `generated_types` and `grpc-binary-logger-proto` crates.