### PR TITLE
fix: Downgrade chrono to avoid conflict with arrow-arith

### DIFF
--- a/partition/Cargo.toml
+++ b/partition/Cargo.toml
@@ -10,7 +10,8 @@ workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-chrono = { version = "0.4", default-features = false }
+# Locked because of https://github.com/apache/arrow-rs/issues/7196
+chrono = { version = "= 0.4.39", default-features = false }
 data_types = { path = "../data_types" }
 hashbrown = { workspace = true }
 mutable_batch = { path = "../mutable_batch" }


### PR DESCRIPTION
See <https://github.com/apache/arrow-rs/issues/7196>.

I'm guessing yinz have lockfiles that prevent this from happening, but I just checked out this repo and couldn't build because of this. Feel free to close if you don't want this!