### PR TITLE
chore: disable `aws-lc`

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -38,6 +38,19 @@ workspace-members = [
 ]
 third-party = [
     { name = "criterion" },
+    { name = "tikv-jemalloc-sys" },
+    # Exclude crypto libraries to control provider selection per-crate
+    # This allows us to use ring consistently without hakari forcing aws-lc-rs
+    { name = "rustls" },
+    { name = "rustls-webpki" },
+    { name = "tokio-rustls" },
+    { name = "hyper-rustls" },
+    { name = "rustls-pemfile" },
+    { name = "rustls-native-certs" },
+    { name = "webpki-roots" },
+    { name = "aws-lc-rs" },
+    { name = "aws-lc-sys" },
+    { name = "ring" },
 ]
 
 #

--- a/client_util/Cargo.toml
+++ b/client_util/Cargo.toml
@@ -15,7 +15,7 @@ iox_http_util = { path = "../iox_http_util" }
 reqwest = { workspace = true, features = ["stream", "rustls-tls-native-roots"] }
 # This direct dependency on rustls can probably be removed when tonic is upgraded to 0.13+.
 # See <https://github.com/influxdata/influxdb_iox/issues/14683> for more details.
-rustls = { version = "0.23", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
 thiserror = "2.0.12"
 tonic = { version = "0.12", features = ["tls", "tls-native-roots"] }
 tower = { workspace = true }

--- a/disable-aws-lc.patch
+++ b/disable-aws-lc.patch
@@ -1,0 +1,236 @@
+diff --git a/.config/hakari.toml b/.config/hakari.toml
+index afa28a701..187e6f5ed 100644
+--- a/.config/hakari.toml
++++ b/.config/hakari.toml
+@@ -42,6 +42,18 @@ workspace-members = [
+ third-party = [
+     { name = "criterion" },
+     { name = "tikv-jemalloc-sys" },
++    # Exclude crypto libraries to control provider selection per-crate
++    # This allows us to use ring consistently without hakari forcing aws-lc-rs
++    { name = "rustls" },
++    { name = "rustls-webpki" },
++    { name = "tokio-rustls" },
++    { name = "hyper-rustls" },
++    { name = "rustls-pemfile" },
++    { name = "rustls-native-certs" },
++    { name = "webpki-roots" },
++    { name = "aws-lc-rs" },
++    { name = "aws-lc-sys" },
++    { name = "ring" },
+ ]
+ 
+ #
+diff --git a/Cargo.lock b/Cargo.lock
+index 8334fef52..cf369799b 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -11541,14 +11541,12 @@ dependencies = [
+  "futures-task",
+  "futures-util",
+  "generic-array",
+- "getrandom 0.2.15",
+  "getrandom 0.3.1",
+  "hashbrown 0.14.5",
+  "hashbrown 0.15.2",
+  "hickory-proto",
+  "httparse",
+  "hyper 1.6.0",
+- "hyper-rustls 0.27.2",
+  "hyper-util",
+  "indexmap 2.10.0",
+  "insta",
+@@ -11582,10 +11580,6 @@ dependencies = [
+  "regex-automata 0.4.9",
+  "regex-syntax 0.8.5",
+  "reqwest",
+- "ring",
+- "rustls 0.23.29",
+- "rustls-pemfile 2.2.0",
+- "rustls-webpki 0.103.4",
+  "serde",
+  "serde_json",
+  "sha2",
+@@ -11609,7 +11603,6 @@ dependencies = [
+  "time",
+  "tokio",
+  "tokio-metrics",
+- "tokio-rustls 0.26.2",
+  "tokio-stream",
+  "tokio-util",
+  "tonic 0.12.3",
+diff --git a/client_util/Cargo.toml b/client_util/Cargo.toml
+index a6ace9b62..8d5dc7a90 100644
+--- a/client_util/Cargo.toml
++++ b/client_util/Cargo.toml
+@@ -15,7 +15,7 @@ iox_http_util = { path = "../iox_http_util" }
+ reqwest = { workspace = true, features = ["stream", "rustls-tls-native-roots"] }
+ # This direct dependency on rustls can probably be removed when tonic is upgraded to 0.13+.
+ # See <https://github.com/influxdata/influxdb_iox/issues/14683> for more details.
+-rustls = { version = "0.23", default-features = false }
++rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
+ thiserror = "2.0.12"
+ tonic = { version = "0.12", features = ["tls", "tls-native-roots"] }
+ tower = { workspace = true }
+diff --git a/iox_auth/Cargo.toml b/iox_auth/Cargo.toml
+index 37bec904a..a6702b61c 100644
+--- a/iox_auth/Cargo.toml
++++ b/iox_auth/Cargo.toml
+@@ -21,7 +21,7 @@ tracing = { workspace = true }
+ prost = { workspace = true }
+ ring = "0.17"
+ reqwest = { version = "0.12.22", default-features = false, features = [
+-    "rustls-tls",
++    "rustls-tls-native-roots",
+ ] }
+ serde = { version = "1.0", features = ["derive"] }
+ serde_json = "1.0.142"
+diff --git a/workspace-hack/Cargo.toml b/workspace-hack/Cargo.toml
+index 374af3259..5e0b1d8f4 100644
+--- a/workspace-hack/Cargo.toml
++++ b/workspace-hack/Cargo.toml
+@@ -55,8 +55,7 @@ futures-sink = { version = "0.3" }
+ futures-task = { version = "0.3", default-features = false, features = ["std"] }
+ futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+ generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
+-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
++getrandom = { version = "0.3", default-features = false, features = ["std"] }
+ hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
+ hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw"] }
+ hickory-proto = { version = "0.25", default-features = false, features = ["serde", "text-parsing", "tokio"] }
+@@ -93,10 +92,6 @@ regex = { version = "1" }
+ regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+ regex-syntax = { version = "0.8" }
+ reqwest = { version = "0.12", default-features = false, features = ["gzip", "http2", "json", "multipart", "rustls-tls", "rustls-tls-native-roots", "stream"] }
+-ring = { version = "0.17", features = ["std"] }
+-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+-rustls-pemfile = { version = "2" }
+-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+ serde = { version = "1", features = ["alloc", "derive", "rc"] }
+ serde_json = { version = "1", features = ["raw_value"] }
+ sha2 = { version = "0.10", features = ["oid"] }
+@@ -116,7 +111,6 @@ thrift = { version = "0.17" }
+ time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
+ tokio = { version = "1", features = ["full", "test-util", "tracing"] }
+ tokio-metrics = { version = "0.4" }
+-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+ tokio-stream = { version = "0.1", features = ["fs", "net"] }
+ tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
+ tonic = { version = "0.12", features = ["tls-roots"] }
+@@ -159,8 +153,7 @@ futures-sink = { version = "0.3" }
+ futures-task = { version = "0.3", default-features = false, features = ["std"] }
+ futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+ generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
+-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
++getrandom = { version = "0.3", default-features = false, features = ["std"] }
+ hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
+ hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw"] }
+ httparse = { version = "1" }
+@@ -191,10 +184,6 @@ regex = { version = "1" }
+ regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+ regex-syntax = { version = "0.8" }
+ reqwest = { version = "0.12", default-features = false, features = ["gzip", "http2", "json", "multipart", "rustls-tls", "rustls-tls-native-roots", "stream"] }
+-ring = { version = "0.17", features = ["std"] }
+-rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+-rustls-pemfile = { version = "2" }
+-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+ serde = { version = "1", features = ["alloc", "derive", "rc"] }
+ serde_json = { version = "1", features = ["raw_value"] }
+ sha2 = { version = "0.10", features = ["oid"] }
+@@ -225,7 +214,6 @@ zstd-sys = { version = "2", default-features = false, features = ["legacy", "std
+ [target.x86_64-unknown-linux-gnu.dependencies]
+ async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+ bitflags = { version = "2", default-features = false, features = ["std"] }
+-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+ hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
+ lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
+ nix = { version = "0.30", default-features = false, features = ["fs", "ioctl", "poll", "signal", "socket", "term"] }
+@@ -236,12 +224,10 @@ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+ [target.x86_64-unknown-linux-gnu.build-dependencies]
+ async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+ bitflags = { version = "2", default-features = false, features = ["std"] }
+-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+ hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
+ ipnet = { version = "2", features = ["serde"] }
+ lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
+ socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
+-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+ tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "timeout"] }
+ tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
+ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+@@ -249,7 +235,6 @@ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+ [target.x86_64-apple-darwin.dependencies]
+ async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+ bitflags = { version = "2", default-features = false, features = ["std"] }
+-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+ hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
+ lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
+ nix = { version = "0.30", default-features = false, features = ["fs", "ioctl", "poll", "signal", "socket", "term"] }
+@@ -260,12 +245,10 @@ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+ [target.x86_64-apple-darwin.build-dependencies]
+ async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+ bitflags = { version = "2", default-features = false, features = ["std"] }
+-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+ hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
+ ipnet = { version = "2", features = ["serde"] }
+ lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
+ socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
+-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+ tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "timeout"] }
+ tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
+ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+@@ -273,7 +256,6 @@ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+ [target.aarch64-apple-darwin.dependencies]
+ async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+ bitflags = { version = "2", default-features = false, features = ["std"] }
+-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+ hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
+ lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
+ nix = { version = "0.30", default-features = false, features = ["fs", "ioctl", "poll", "signal", "socket", "term"] }
+@@ -284,19 +266,16 @@ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+ [target.aarch64-apple-darwin.build-dependencies]
+ async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+ bitflags = { version = "2", default-features = false, features = ["std"] }
+-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+ hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
+ ipnet = { version = "2", features = ["serde"] }
+ lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
+ socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
+-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+ tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "timeout"] }
+ tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
+ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+ 
+ [target.x86_64-pc-windows-msvc.dependencies]
+ async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+ hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
+ lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
+ socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false, features = ["all"] }
+@@ -304,22 +283,20 @@ tower = { version = "0.5", default-features = false, features = ["timeout"] }
+ tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
+ winapi = { version = "0.3", default-features = false, features = ["cfg", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "in6addr", "inaddr", "minwinbase", "minwindef", "ntsecapi", "processenv", "profileapi", "windef", "winioctl", "winnt"] }
+ windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+-windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
++windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+ windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_Debug", "Win32_System_Registry", "Win32_System_Time", "Win32_UI_Shell"] }
+ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+ 
+ [target.x86_64-pc-windows-msvc.build-dependencies]
+ async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
+-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
+ hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
+ ipnet = { version = "2", features = ["serde"] }
+ lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
+ socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
+-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+ tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "timeout"] }
+ tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
+ windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
+-windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
++windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
+ windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_Debug", "Win32_System_Registry", "Win32_System_Time", "Win32_UI_Shell"] }
+ xz2 = { version = "0.1", default-features = false, features = ["static"] }
+ 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -23,115 +23,73 @@ ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] 
 arrayvec = { version = "0.7", default-features = false, features = ["std"] }
 arrow-ipc = { version = "55", features = ["lz4"] }
 arrow-schema = { version = "55", default-features = false, features = ["canonical_extension_types"] }
-aws-credential-types = { version = "1", default-features = false, features = ["test-util"] }
-aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
-aws-smithy-runtime = { version = "1", default-features = false, features = ["client", "default-https-client", "rt-tokio", "tls-rustls"] }
-aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "http-auth", "test-util"] }
-aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
 base64 = { version = "0.22" }
-bigdecimal = { version = "0.4", features = ["serde"] }
-bincode = { version = "2", default-features = false, features = ["alloc", "derive", "serde"] }
-bloom2 = { version = "0.5", default-features = false, features = ["serde"] }
 byteorder = { version = "1" }
 bytes = { version = "1" }
-chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive", "env", "string"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "string", "suggestions", "usage"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
 crossbeam-utils = { version = "0.8" }
-crypto-bigint = { version = "0.5", features = ["generic-array", "zeroize"] }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 datafusion-common = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "de1eb41e301a53e4916a5f1792e403fb68dd6106", default-features = false, features = ["object_store", "parquet", "recursive_protection"] }
 datafusion-expr = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "de1eb41e301a53e4916a5f1792e403fb68dd6106", default-features = false, features = ["recursive_protection"] }
-digest = { version = "0.10", features = ["mac", "oid", "std"] }
+digest = { version = "0.10", features = ["mac", "std"] }
 either = { version = "1", features = ["serde", "use_std"] }
 fastrand = { version = "2" }
-flatbuffers = { version = "25" }
 flate2 = { version = "1", features = ["zlib-rs"] }
 form_urlencoded = { version = "1" }
+futures = { version = "0.3" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
 futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "channel", "io", "sink"] }
+getrandom = { version = "0.3", default-features = false, features = ["std"] }
 hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw"] }
-hickory-proto = { version = "0.25", default-features = false, features = ["serde", "text-parsing", "tokio"] }
 httparse = { version = "1" }
 hyper = { version = "1", features = ["client", "http1", "http2", "server"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "server-auto", "server-graceful", "service"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "server-auto", "service"] }
 indexmap = { version = "2" }
-insta = { version = "1", features = ["json", "redactions", "yaml"] }
-ipnet = { version = "2", features = ["serde"] }
-itertools-594e8ee84c453af0 = { package = "itertools", version = "0.13" }
-itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12", default-features = false, features = ["use_alloc"] }
-libc = { version = "0.2", features = ["extra_traits", "use_std"] }
-lock_api = { version = "0.4", features = ["arc_lock"] }
+libc = { version = "0.2", features = ["use_std"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 md-5 = { version = "0.10" }
 memchr = { version = "2" }
-moka = { version = "0.12", features = ["future", "sync"] }
-num-bigint = { version = "0.4", features = ["serde"] }
-num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
-once_cell = { version = "1", features = ["critical-section"] }
-parking_lot = { version = "0.12", features = ["arc_lock"] }
 percent-encoding = { version = "2" }
-portable-atomic = { version = "1" }
-proptest = { version = "1" }
 prost = { version = "0.13", features = ["prost-derive"] }
 prost-types = { version = "0.13" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
 rand_chacha = { version = "0.9", default-features = false, features = ["std"] }
-rand_core = { version = "0.9", default-features = false, features = ["os_rng", "std"] }
 regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["gzip", "http2", "json", "multipart", "rustls-tls", "rustls-tls-native-roots", "stream"] }
-ring = { version = "0.17", features = ["std"] }
-rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-pemfile = { version = "2" }
-rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls-native-roots", "stream"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }
-sha2 = { version = "0.10", features = ["oid"] }
-signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
+sha2 = { version = "0.10" }
 similar = { version = "2", features = ["inline"] }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union"] }
-snafu = { version = "0.8", features = ["futures"] }
-socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
-sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "sqlite", "tls-rustls", "uuid"] }
+socket2 = { version = "0.6", default-features = false, features = ["all"] }
 sqlx-core = { version = "0.8", features = ["_rt-tokio", "_tls-rustls-ring-webpki", "any", "json", "migrate", "offline", "uuid"] }
 sqlx-postgres = { version = "0.8", default-features = false, features = ["any", "json", "migrate", "offline", "uuid"] }
 sqlx-sqlite = { version = "0.8", default-features = false, features = ["any", "bundled", "json", "migrate", "offline", "uuid"] }
-subtle = { version = "2" }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-thiserror = { version = "2" }
 thrift = { version = "0.17" }
-time = { version = "0.3", features = ["formatting", "macros", "parsing"] }
-tokio = { version = "1", features = ["full", "test-util", "tracing"] }
-tokio-metrics = { version = "0.4" }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
+tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "test-util"] }
 tokio-stream = { version = "0.1", features = ["fs", "net"] }
-tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
 tonic = { version = "0.12", features = ["tls-roots"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit"] }
-tracing = { version = "0.1", features = ["log", "max_level_trace"] }
+tower = { version = "0.5", default-features = false, features = ["util"] }
+tracing = { version = "0.1", features = ["log", "max_level_trace", "release_max_level_trace"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
-twox-hash = { version = "2" }
-url = { version = "2", features = ["serde"] }
-uuid = { version = "1", features = ["js", "serde", "v4", "v7"] }
-zeroize = { version = "1", features = ["derive", "std"] }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
+twox-hash = { version = "2", default-features = false, features = ["xxhash32", "xxhash64"] }
+uuid = { version = "1", features = ["js", "v4"] }
 
 [build-dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
@@ -141,187 +99,115 @@ base64 = { version = "0.22" }
 byteorder = { version = "1" }
 bytes = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 crossbeam-utils = { version = "0.8" }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 datafusion-common = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "de1eb41e301a53e4916a5f1792e403fb68dd6106", default-features = false, features = ["object_store", "parquet", "recursive_protection"] }
 datafusion-expr = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "de1eb41e301a53e4916a5f1792e403fb68dd6106", default-features = false, features = ["recursive_protection"] }
-digest = { version = "0.10", features = ["mac", "oid", "std"] }
+digest = { version = "0.10", features = ["mac", "std"] }
 either = { version = "1", features = ["serde", "use_std"] }
 fastrand = { version = "2" }
-flatbuffers = { version = "25" }
 flate2 = { version = "1", features = ["zlib-rs"] }
 form_urlencoded = { version = "1" }
+futures = { version = "0.3" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-executor = { version = "0.3" }
 futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", default-features = false, features = ["async-await-macro", "channel", "io", "sink"] }
+getrandom = { version = "0.3", default-features = false, features = ["std"] }
 hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15" }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw"] }
 httparse = { version = "1" }
 hyper = { version = "1", features = ["client", "http1", "http2", "server"] }
 indexmap = { version = "2" }
-itertools-594e8ee84c453af0 = { package = "itertools", version = "0.13" }
-itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12", default-features = false, features = ["use_alloc"] }
-libc = { version = "0.2", features = ["extra_traits", "use_std"] }
-lock_api = { version = "0.4", features = ["arc_lock"] }
+libc = { version = "0.2", features = ["use_std"] }
 log = { version = "0.4", default-features = false, features = ["std"] }
 md-5 = { version = "0.10" }
 memchr = { version = "2" }
-num-bigint = { version = "0.4", features = ["serde"] }
-num-integer = { version = "0.1", features = ["i128"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 object_store = { version = "0.12", features = ["aws", "azure", "gcp"] }
-once_cell = { version = "1", features = ["critical-section"] }
-parking_lot = { version = "0.12", features = ["arc_lock"] }
 percent-encoding = { version = "2" }
-portable-atomic = { version = "1" }
 prost = { version = "0.13", features = ["prost-derive"] }
 prost-types = { version = "0.13" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
 rand_chacha = { version = "0.9", default-features = false, features = ["std"] }
-rand_core = { version = "0.9", default-features = false, features = ["os_rng", "std"] }
 regex = { version = "1" }
-regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
 regex-syntax = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["gzip", "http2", "json", "multipart", "rustls-tls", "rustls-tls-native-roots", "stream"] }
-ring = { version = "0.17", features = ["std"] }
-rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "aws_lc_rs", "logging", "ring", "std", "tls12"] }
-rustls-pemfile = { version = "2" }
-rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
+reqwest = { version = "0.12", default-features = false, features = ["http2", "json", "rustls-tls-native-roots", "stream"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1", features = ["raw_value"] }
-sha2 = { version = "0.10", features = ["oid"] }
+sha2 = { version = "0.10" }
 smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union"] }
 sqlx-core = { version = "0.8", features = ["_rt-tokio", "_tls-rustls-ring-webpki", "any", "json", "migrate", "offline", "uuid"] }
-sqlx-macros = { version = "0.8", features = ["_rt-tokio", "_tls-rustls-ring-webpki", "derive", "json", "macros", "migrate", "postgres", "sqlite", "uuid"] }
-sqlx-macros-core = { version = "0.8", features = ["_rt-tokio", "_tls-rustls-ring-webpki", "derive", "json", "macros", "migrate", "postgres", "sqlite", "uuid"] }
 sqlx-postgres = { version = "0.8", default-features = false, features = ["any", "json", "migrate", "offline", "uuid"] }
 sqlx-sqlite = { version = "0.8", default-features = false, features = ["any", "bundled", "json", "migrate", "offline", "uuid"] }
-subtle = { version = "2" }
 syn = { version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-thiserror = { version = "2" }
 thrift = { version = "0.17" }
-tokio = { version = "1", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "parking_lot", "rt-multi-thread", "signal", "test-util"] }
 tokio-stream = { version = "0.1", features = ["fs", "net"] }
-tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
-tracing = { version = "0.1", features = ["log", "max_level_trace"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+tracing = { version = "0.1", features = ["log", "max_level_trace", "release_max_level_trace"] }
 tracing-core = { version = "0.1" }
-twox-hash = { version = "2" }
-url = { version = "2", features = ["serde"] }
-uuid = { version = "1", features = ["js", "serde", "v4", "v7"] }
-zeroize = { version = "1", features = ["derive", "std"] }
-zstd = { version = "0.13" }
-zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
-zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder"] }
+twox-hash = { version = "2", default-features = false, features = ["xxhash32", "xxhash64"] }
+uuid = { version = "1", features = ["js", "v4"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
-lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
-nix = { version = "0.30", default-features = false, features = ["fs", "ioctl", "poll", "signal", "socket", "term"] }
+once_cell = { version = "1" }
 tower = { version = "0.5", default-features = false, features = ["timeout"] }
-tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
-xz2 = { version = "0.1", default-features = false, features = ["static"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
-ipnet = { version = "2", features = ["serde"] }
-lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
-socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "timeout"] }
-tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
-xz2 = { version = "0.1", default-features = false, features = ["static"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+once_cell = { version = "1" }
+socket2 = { version = "0.6", default-features = false, features = ["all"] }
+tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
 
 [target.x86_64-apple-darwin.dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
-lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
-nix = { version = "0.30", default-features = false, features = ["fs", "ioctl", "poll", "signal", "socket", "term"] }
+once_cell = { version = "1" }
 tower = { version = "0.5", default-features = false, features = ["timeout"] }
-tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
-xz2 = { version = "0.1", default-features = false, features = ["static"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
-ipnet = { version = "2", features = ["serde"] }
-lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
-socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "timeout"] }
-tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
-xz2 = { version = "0.1", default-features = false, features = ["static"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+once_cell = { version = "1" }
+socket2 = { version = "0.6", default-features = false, features = ["all"] }
+tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
 
 [target.aarch64-apple-darwin.dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
-lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
-nix = { version = "0.30", default-features = false, features = ["fs", "ioctl", "poll", "signal", "socket", "term"] }
+once_cell = { version = "1" }
 tower = { version = "0.5", default-features = false, features = ["timeout"] }
-tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
-xz2 = { version = "0.1", default-features = false, features = ["static"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
-ipnet = { version = "2", features = ["serde"] }
-lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
-socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "timeout"] }
-tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
-xz2 = { version = "0.1", default-features = false, features = ["static"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+once_cell = { version = "1" }
+socket2 = { version = "0.6", default-features = false, features = ["all"] }
+tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 hyper-util = { version = "0.1", default-features = false, features = ["client-proxy"] }
-lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
-socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false, features = ["all"] }
+once_cell = { version = "1" }
 tower = { version = "0.5", default-features = false, features = ["timeout"] }
-tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
-winapi = { version = "0.3", default-features = false, features = ["cfg", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "in6addr", "inaddr", "minwinbase", "minwindef", "ntsecapi", "processenv", "profileapi", "windef", "winioctl", "winnt"] }
-windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
-windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_Debug", "Win32_System_Registry", "Win32_System_Time", "Win32_UI_Shell"] }
-xz2 = { version = "0.1", default-features = false, features = ["static"] }
+winapi = { version = "0.3", default-features = false, features = ["cfg", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "in6addr", "inaddr", "minwinbase", "ntsecapi", "processenv", "windef", "winioctl"] }
+windows-sys = { version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
-async-compression = { version = "0.4", default-features = false, features = ["bzip2", "gzip", "tokio", "xz", "zstd"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
-hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "server-graceful", "service"] }
-ipnet = { version = "2", features = ["serde"] }
-lzma-sys = { version = "0.1", default-features = false, features = ["static"] }
-socket2-3b31131e45eafb45 = { package = "socket2", version = "0.6", default-features = false, features = ["all"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "ring", "tls12"] }
-tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "timeout"] }
-tower-http = { version = "0.6", features = ["catch-panic", "follow-redirect"] }
-windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
-windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_Debug", "Win32_System_Registry", "Win32_System_Time", "Win32_UI_Shell"] }
-xz2 = { version = "0.1", default-features = false, features = ["static"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "client-proxy", "server-auto", "service"] }
+once_cell = { version = "1" }
+socket2 = { version = "0.6", default-features = false, features = ["all"] }
+tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+windows-sys = { version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
### Summary

- This commit is unusual, this is not replicating what is in `iox`, this is a unique commit only present in `influxdb3_core` but changing `iox` dependencies. The main purpose is to disable `aws-lc` and use `ring` consistently everywhere. This allows upstream projects that depend on this not run into errors during cross compilation
- Added the patch file for visibility, if incase we need to pull again from `iox` and if it overwrites these changes it's useful to have this patch file to reapply again as-is or with changes

### Manual checks

I've tried to test this against `influxdb3` locally without using any extra feature flags and that results in

```
❯ cargo tree -i aws-lc-sys
error: package ID specification `aws-lc-sys` did not match any packages
```