### PR TITLE
fix(trace_http): drop path labels for gRPC unimplemented

### DIFF
--- a/trace_http/src/classify.rs
+++ b/trace_http/src/classify.rs
@@ -103,7 +103,9 @@ pub(crate) fn classify_headers(
                 9 => ("failed precondition".into(), Classification::ClientErr),
                 10 => ("aborted".into(), Classification::ClientErr),
                 11 => ("out of range".into(), Classification::ClientErr),
-                12 => ("unimplemented".into(), Classification::ClientErr),
+                // Treated as PathNotFound to align with HTTP 404 Not Found so that the path is not
+                // included in the metrics to prevent metric cardinality explosion.
+                12 => ("unimplemented".into(), Classification::PathNotFound),
                 13 => ("internal".into(), Classification::ServerErr),
                 14 => ("unavailable".into(), Classification::ServerErr),
                 15 => ("data loss".into(), Classification::ServerErr),


### PR DESCRIPTION
Unimplemented gRPC methods return status 12, so we now classify those as `PathNotFound` so metrics keep the count but strip the path label. This helps to avoid metric cardinality explosion.

Legitimate gRPC not found (status 5) remains untouched to preserve useful metrics.

**Tested**

I tested this by running this locally and I could easily reproduce the previous behavior of inc bogus metrics which causes a metrics cardinality explosion. After this patch the metric series doesn't include the path label so we reduce that high cardinality.